### PR TITLE
Replace lru with lru-cache

### DIFF
--- a/js/sigplot.layer1dSDS.js
+++ b/js/sigplot.layer1dSDS.js
@@ -31,7 +31,7 @@
     var m = require("./m");
     var mx = require("./mx");
     var common = require("./common");
-    var LRU = require("lru");
+    var LRU = require("lru-cache");
 
     /**
      * @constructor

--- a/js/sigplot.layer2dSDS.js
+++ b/js/sigplot.layer2dSDS.js
@@ -127,7 +127,7 @@
             }
 
             this.hcb.class = 2;
-            const LRU = require("lru");
+            const LRU = require("lru-cache");
 
             this.cache = new LRU(500);
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "budo": "^11.6.4",
     "loglevel": "^1.4.1",
-    "lru": "^3.1.0",
+    "lru-cache": "^2.7.3",
     "sigfile": "^0.1.9",
     "spin": "0.0.1",
     "tinycolor2": "^1.4.1",


### PR DESCRIPTION
They have an identical API (for our purposes), but lru-cache is fully browser-ready, whereas lru has some node-specific requirements (i.e., namely the `events` library). In my update-tooling effort, lru caused `esbuild` to error, while lru-cache did not. Also, lru was last updated 5 years ago, whereas lru-cache was last updated 10 months ago.

Note: I have verified SDS functionality remained the same.