### PR TITLE
Correct 1D plot zoom rendering

### DIFF
--- a/js/mx.js
+++ b/js/mx.js
@@ -1046,86 +1046,86 @@
                 }
                 /* FALL THROUGH!!! */
                 /* jshint -W086 */
-                case mx.XW_COMMAND:
-                    /* jshint +W086 */
+            case mx.XW_COMMAND:
+                /* jshint +W086 */
 
-                    smin = sv.smin;
-                    srange = sv.srange;
+                smin = sv.smin;
+                srange = sv.srange;
 
-                    switch (sv.action) {
-                        case mx.SB_STEPINC:
-                            smin += sv.step;
-                            break;
-                        case mx.SB_STEPDEC:
-                            smin -= sv.step;
-                            break;
-                        case mx.SB_PAGEINC:
-                            smin += sv.page;
-                            break;
-                        case mx.SB_PAGEDEC:
-                            smin -= sv.page;
-                            break;
-                        case mx.SB_FULL:
-                            smin = sv.tmin;
-                            srange = sv.trange;
-                            break;
-                        case mx.SB_EXPAND:
-                            srange = srange * sv.scale;
-                            if (smin <= 0 && smin + sv.srange >= 0) {
-                                smin *= sv.scale;
-                            } else {
-                                smin -= (srange - sv.srange) / 2.0;
-                            }
-                            break;
-                        case mx.SB_SHRINK:
-                            srange = srange / sv.scale;
-                            if (smin < 0 && smin + sv.srange >= 0) {
-                                smin += srange / sv.scale; /* Plot crosses axis */
-                            } else if (smin === 0 && smin + sv.srange >= 0) {
-                                smin = srange / sv.scale; /* Plot touches axis */
-                            } else {
-                                smin += (sv.srange - srange) / 2.0; /* Plot is completely contained on positive side of axis */
-                            }
-                            break;
-                            /* The mouse wheel needs to scroll 1 page at a time, if you want an
+                switch (sv.action) {
+                    case mx.SB_STEPINC:
+                        smin += sv.step;
+                        break;
+                    case mx.SB_STEPDEC:
+                        smin -= sv.step;
+                        break;
+                    case mx.SB_PAGEINC:
+                        smin += sv.page;
+                        break;
+                    case mx.SB_PAGEDEC:
+                        smin -= sv.page;
+                        break;
+                    case mx.SB_FULL:
+                        smin = sv.tmin;
+                        srange = sv.trange;
+                        break;
+                    case mx.SB_EXPAND:
+                        srange = srange * sv.scale;
+                        if (smin <= 0 && smin + sv.srange >= 0) {
+                            smin *= sv.scale;
+                        } else {
+                            smin -= (srange - sv.srange) / 2.0;
+                        }
+                        break;
+                    case mx.SB_SHRINK:
+                        srange = srange / sv.scale;
+                        if (smin < 0 && smin + sv.srange >= 0) {
+                            smin += srange / sv.scale; /* Plot crosses axis */
+                        } else if (smin === 0 && smin + sv.srange >= 0) {
+                            smin = srange / sv.scale; /* Plot touches axis */
+                        } else {
+                            smin += (sv.srange - srange) / 2.0; /* Plot is completely contained on positive side of axis */
+                        }
+                        break;
+                        /* The mouse wheel needs to scroll 1 page at a time, if you want an
 		           application to scroll differently, change sv.page with
 		           mx_scroll_vals in the application code */
-                        case mx.SB_WHEELUP:
-                            smin -= sv.page;
-                            break;
-                        case mx.SB_WHEELDOWN:
-                            smin += sv.page;
-                            break;
-                    }
+                    case mx.SB_WHEELUP:
+                        smin -= sv.page;
+                        break;
+                    case mx.SB_WHEELDOWN:
+                        smin += sv.page;
+                        break;
+                }
 
-                    if (sv.trange > 0) {
-                        smin = Math.max(sv.tmin, Math.min(smin, sv.tmin + sv.trange - srange));
-                        srange = Math.min(srange, sv.trange);
-                    } else {
-                        smin = Math.min(sv.tmin, Math.max(smin, sv.tmin + sv.trange - srange));
-                        srange = Math.max(srange, sv.trange);
-                    }
+                if (sv.trange > 0) {
+                    smin = Math.max(sv.tmin, Math.min(smin, sv.tmin + sv.trange - srange));
+                    srange = Math.min(srange, sv.trange);
+                } else {
+                    smin = Math.min(sv.tmin, Math.max(smin, sv.tmin + sv.trange - srange));
+                    srange = Math.max(srange, sv.trange);
+                }
 
-                    if (sv.smin === smin && sv.srange === srange) {
-                        if (sv.action !== mx.SB_DRAG) {
-                            sv.action = sv.repeat_count = 0;
-                        }
-                    } else {
-                        // UPDATE SCROLLBAR STATE as well
-                        sv.smin = scrollbarState.smin = smin;
-                        sv.srange = scrollbarState.srange = srange;
-                        sv.repeat_count++;
+                if (sv.smin === smin && sv.srange === srange) {
+                    if (sv.action !== mx.SB_DRAG) {
+                        sv.action = sv.repeat_count = 0;
                     }
+                } else {
+                    // UPDATE SCROLLBAR STATE as well
+                    sv.smin = scrollbarState.smin = smin;
+                    sv.srange = scrollbarState.srange = srange;
+                    sv.repeat_count++;
+                }
 
-                    if (op === mx.XW_COMMAND) {
-                        mx.scroll(Mx, sv, mx.XW_UPDATE, undefined);
-                        sv.action = 0;
-                    }
+                if (op === mx.XW_COMMAND) {
+                    mx.scroll(Mx, sv, mx.XW_UPDATE, undefined);
+                    sv.action = 0;
+                }
 
-                    break;
-                case mx.XW_DRAW:
-                case mx.XW_UPDATE:
-                    mx.redrawScrollbar(sv, Mx, op);
+                break;
+            case mx.XW_DRAW:
+            case mx.XW_UPDATE:
+                mx.redrawScrollbar(sv, Mx, op);
 
         } /* switch */
         return true;

--- a/js/sigplot.layer1d.js
+++ b/js/sigplot.layer1d.js
@@ -278,6 +278,8 @@
                 imin = imax - npts + 1;
             }
 
+            this.imin = imin;
+
             if ((this.ybufmin !== undefined) && (this.ybufmax !== undefined) && (imin >= this.ybufmin) && (imin + npts <= this.ybufmax)) {
                 // data already in buffers
                 return npts;
@@ -466,7 +468,7 @@
             var Gx = this.plot._Gx;
             var Mx = this.plot._Mx;
 
-            var npts = this.get_data(xmin, xmax);;
+            var npts = this.get_data(xmin, xmax);
             if (this.mode === "XY") {
                 npts = Math.floor(npts / 2);
             }
@@ -543,35 +545,34 @@
                 //    this.xmax = qmax;
                 //}
             } else if (npts > 0) {
-                var xstart = this.xstart;
+                var xstart = this.hcb.xstart + this.imin * this.xdelta;
                 var xdelta = this.xdelta;
                 var d = npts;
 
-                // n1 and n2 are the minimal and maximal index bounds based on the
-                // passed in xmin/xmax, but get_data may have returned less data
                 if (Gx.index) {
                     n1 = 0;
                     n2 = npts - 1;
                 } else if (xdelta >= 0.0) {
-                    n1 = Math.max(1.0, Math.min(this.size, Math.round((xmin - xstart) / xdelta))) - 1.0;
-                    n2 = Math.max(1.0, Math.min(this.size, Math.round((xmax - xstart) / xdelta) + 2.0)) - 1.0;
+                    n1 = Math.max(1.0, Math.min(d, Math.round((xmin - xstart) / xdelta))) - 1.0;
+                    n2 = Math.max(1.0, Math.min(d, Math.round((xmax - xstart) / xdelta) + 2.0)) - 1.0;
                 } else {
-                    n1 = Math.max(1.0, Math.min(this.size, Math.round((xmax - xstart) / xdelta) - 1.0)) - 1.0;
-                    n2 = Math.max(1.0, Math.min(this.size, Math.round((xmin - xstart) / xdelta) + 2.0)) - 1.0;
+                    n1 = Math.max(1.0, Math.min(d, Math.round((xmax - xstart) / xdelta) - 1.0)) - 1.0;
+                    n2 = Math.max(1.0, Math.min(d, Math.round((xmin - xstart) / xdelta) + 2.0)) - 1.0;
                 }
 
-                n2 = Math.min(n2, n1 + d - 1);
+                npts = n2 - n1 + 1;
                 if (npts < 0) {
                     m.log.debug("Nothing to plot");
                     npts = 0;
                 }
-                dbuf = new m.PointArray(this.ybuf);
+                var bufoff = (this.imin - (this.ybufmin || 0)) + n1;
+                dbuf = new m.PointArray(this.ybuf).subarray(bufoff * skip);
                 xstart = xstart + xdelta * (n1);
                 for (var i = 0; i < npts; i++) {
                     if (Gx.index) {
-                        this.xpoint[i] = this.imin + i + 1;
+                        this.xpoint[i] = this.imin + n1 + i + 1;
                     } else {
-                        this.xpoint[i] = xmin + i * xdelta;
+                        this.xpoint[i] = xstart + i * xdelta;
                     }
                 }
             }
@@ -808,6 +809,13 @@
                 if (xmin >= xmax) { // no data but do scaling
                     Gx.panxmin = Math.min(Gx.panxmin, this.xmin);
                     Gx.panxmax = Math.max(Gx.panxmax, this.xmax);
+                    return {
+                        num: 0,
+                        xmin: this.xmin,
+                        xmax: this.xmax,
+                        ymin: this.ymin,
+                        ymax: this.ymax
+                    };
                 }
             }
 

--- a/test/tests.interactive-layer1d.js
+++ b/test/tests.interactive-layer1d.js
@@ -1828,7 +1828,7 @@ interactiveTest('1d negative xstart gt bufmax', 'does the plot display a full tr
         all: true,
         expand: true,
     };
-    
+
     var plot = new sigplot.Plot(document.getElementById('plot'), plot_options);
 
     var num_elements = (plot._Gx.bufmax * 4);
@@ -1838,19 +1838,19 @@ interactiveTest('1d negative xstart gt bufmax', 'does the plot display a full tr
 
     var val = 1;
     var data = []; // the series of y-values
-    for (var ii=0; ii<num_elements; ii++) {
+    for (var ii = 0; ii < num_elements; ii++) {
         data.push(val);
-        if (ii < num_elements/2) {
-        val = val + 1;
+        if (ii < num_elements / 2) {
+            val = val + 1;
         } else {
-        val = val - 1;
+            val = val - 1;
         }
     }
-    
+
     let xdelta = 50;
     var data_header = {
         xunits: "Time",
-        xstart: -1 * (num_elements/2) * xdelta, // the start of the x-axis
+        xstart: -1 * (num_elements / 2) * xdelta, // the start of the x-axis
         xdelta: xdelta, // the x-axis step between each data point
         yunits: "Power"
     };


### PR DESCRIPTION
Restore this.imin tracking in get_data() so prep() can compute correct buffer offsets. Fix prep() to use sample-aligned xstart, cap n1/n2 to fetched point count, restore subarray slicing, and use proper x-coordinates. Add early return in draw() when zoom region has no data overlap to prevent undefined ymin/ymax.